### PR TITLE
Fix URL

### DIFF
--- a/api/KeyAuth.hpp
+++ b/api/KeyAuth.hpp
@@ -540,7 +540,7 @@ namespace KeyAuth {
 
 			std::string to_return;
 
-			curl_easy_setopt(curl, CURLOPT_URL, XorStr("https://keyauth.uk/api/1.0/").c_str());
+			curl_easy_setopt(curl, CURLOPT_URL, XorStr("https://keyauth.win/api/1.0/").c_str());
 
 			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
 			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
Url must be keyauth.win for c++ or else it breaks. Unlike c# and python, c++ cannot be forwarded to new URL unless you add the param `curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);` 

but at that point, it's better to just change the URL since that will be quicker and you must update code anyways